### PR TITLE
ci: 优化 Playwright 浏览器安装与并发策略

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend-tests:
     name: 后端测试
@@ -233,23 +237,39 @@ jobs:
         working-directory: test
         run: pip install -r requirements.txt
 
+      - name: Read Playwright version
+        id: playwright-version
+        working-directory: test
+        run: |
+          echo "version=$(python -c "import importlib.metadata; print(importlib.metadata.version('playwright'))")" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('test/requirements.txt') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
           restore-keys: |
             playwright-${{ runner.os }}-
 
-      - name: Install Playwright browsers
+      - name: Install Playwright system deps
+        timeout-minutes: 5
         working-directory: test
         run: |
+          python -m playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        timeout-minutes: 10
+        working-directory: test
+        env:
+          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: 120000
+        run: |
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" == "true" ]; then
-            python -m playwright install-deps chromium
+            echo "Playwright browser cache hit: ${{ steps.playwright-version.outputs.version }}"
           else
-            python -m playwright install chromium --with-deps
+            echo "Playwright browser cache miss: ${{ steps.playwright-version.outputs.version }}"
           fi
+          python -m playwright install chromium
 
       - name: Run browser E2E tests
         working-directory: test

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
-pytest>=8.0
-pytest-playwright>=0.5
-pytest-xdist>=3.0
-playwright>=1.40
-requests>=2.31
+pytest==9.0.2
+pytest-playwright==0.7.2
+pytest-xdist==3.8.0
+playwright==1.58.0
+requests==2.32.5


### PR DESCRIPTION
## 背景

浏览器 E2E 这个 job 之前容易长时间停在 Playwright 浏览器安装步骤，表现上像流水线卡住。根因主要有两点：

- test/requirements.txt 使用浮动版本，导致 Playwright 包版本和浏览器缓存不稳定
- browser E2E job 的安装逻辑把系统依赖安装和浏览器下载混在一起，cache hit / miss 的行为不够清晰

## 本次改动

- 为 test/requirements.txt 固定 pytest / pytest-playwright / pytest-xdist / playwright / requests 版本
- 在 CI 顶部增加 concurrency，新提交会自动取消旧的同类 run
- browser E2E job 在安装 Python 依赖后读取实际 Playwright 版本
- Playwright 浏览器缓存 key 改为 runner OS + 实际 Playwright 版本
- 将 Playwright 安装拆成两步：
  - install-deps chromium
  - install chromium
- 为 Playwright 安装步骤增加 timeout 和更明确的 cache hit / miss 日志
- 增加 PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT，降低下载阶段的假死感

## 验证

已本地验证：

- ci.yml 可被 YAML 正常解析
- test/browser 可以正常 collect（80 tests）
- git diff --check 通过

## 备注

这次只改 CI 和 test 依赖版本，没有改业务代码。