### PR TITLE
docs: 修复测试文档失效链接并同步代码现状

### DIFF
--- a/docs/测试/1-用户模块测试.md
+++ b/docs/测试/1-用户模块测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [UserServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/user/UserServiceTest.java)
+## [UserServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/user/UserServiceTest.java)
 
 验证手机号验证码登录流程、用户创建/查询、Token 管理等核心用户功能。
 
@@ -42,7 +42,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [SessionServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/user/SessionServiceTest.java)
+## [SessionServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/user/SessionServiceTest.java)
 
 验证会话（Session）的创建和管理，每次请求生成独立的 sessionId。
 
@@ -54,7 +54,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [ClientServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/user/ClientServiceTest.java)
+## [ClientServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/user/ClientServiceTest.java)
 
 验证客户端标识（Client）的创建和管理，为设备标识分配唯一 clientId。
 

--- a/docs/测试/1-用户模块测试.md
+++ b/docs/测试/1-用户模块测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [UserServiceTest](../../video/src/test/java/com/github/makewheels/video2022/user/UserServiceTest.java)
+## [UserServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/user/UserServiceTest.java)
 
 验证手机号验证码登录流程、用户创建/查询、Token 管理等核心用户功能。
 
@@ -42,7 +42,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [SessionServiceTest](../../video/src/test/java/com/github/makewheels/video2022/user/SessionServiceTest.java)
+## [SessionServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/user/SessionServiceTest.java)
 
 验证会话（Session）的创建和管理，每次请求生成独立的 sessionId。
 
@@ -54,7 +54,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [ClientServiceTest](../../video/src/test/java/com/github/makewheels/video2022/user/ClientServiceTest.java)
+## [ClientServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/user/ClientServiceTest.java)
 
 验证客户端标识（Client）的创建和管理，为设备标识分配唯一 clientId。
 

--- a/docs/测试/2-视频模块测试.md
+++ b/docs/测试/2-视频模块测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoServiceTest.java)
+## [VideoServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/VideoServiceTest.java)
 
 验证视频元数据更新、详情查询、列表分页和观看设置等核心功能。
 
@@ -49,7 +49,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoDeleteServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoDeleteServiceTest.java)
+## [VideoDeleteServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/VideoDeleteServiceTest.java)
 
 验证视频删除功能，包括 MongoDB 记录清理、关联文件删除、播放列表清理。
 
@@ -66,7 +66,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoLikeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/like/VideoLikeServiceTest.java)
+## [VideoLikeServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/like/VideoLikeServiceTest.java)
 
 验证视频点赞/点踩功能，包括计数更新、取消、切换和状态查询。
 
@@ -85,7 +85,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CommentServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/comment/CommentServiceTest.java)
+## [CommentServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/comment/CommentServiceTest.java)
 
 验证评论系统功能，包括添加评论/回复、分页查询、删除级联、点赞 toggle 和评论数统计。
 
@@ -114,7 +114,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoCreateServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoCreateServiceTest.java)
+## [VideoCreateServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/VideoCreateServiceTest.java)
 
 验证视频创建流程，包括 USER_UPLOAD 和 YOUTUBE 两种类型的创建，以及参数校验逻辑。
 
@@ -142,7 +142,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoReadyServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoReadyServiceTest.java)
+## [VideoReadyServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/VideoReadyServiceTest.java)
 
 验证视频就绪事件处理，包括存储降级和通知发送逻辑。
 
@@ -155,7 +155,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [LinkServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/LinkServiceTest.java)
+## [LinkServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/LinkServiceTest.java)
 
 验证文件去重链接功能，基于 MD5 判断源视频是否可复用，避免重复存储。
 
@@ -173,7 +173,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [YoutubeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/YoutubeServiceTest.java)
+## [YoutubeServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/video/YoutubeServiceTest.java)
 
 验证 YouTube 视频集成，包括 URL 解析、视频信息获取和文件传输。
 
@@ -190,7 +190,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [WatchServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
+## [WatchServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
 
 验证观看记录功能，包括观看计数、重复观看处理和观看记录清理。
 

--- a/docs/测试/2-视频模块测试.md
+++ b/docs/测试/2-视频模块测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/VideoServiceTest.java)
+## [VideoServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoServiceTest.java)
 
 验证视频元数据更新、详情查询、列表分页和观看设置等核心功能。
 
@@ -49,7 +49,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoDeleteServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/VideoDeleteServiceTest.java)
+## [VideoDeleteServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoDeleteServiceTest.java)
 
 验证视频删除功能，包括 MongoDB 记录清理、关联文件删除、播放列表清理。
 
@@ -66,7 +66,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoLikeServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/like/VideoLikeServiceTest.java)
+## [VideoLikeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/like/VideoLikeServiceTest.java)
 
 验证视频点赞/点踩功能，包括计数更新、取消、切换和状态查询。
 
@@ -85,7 +85,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CommentServiceTest](../../video/src/test/java/com/github/makewheels/video2022/comment/CommentServiceTest.java)
+## [CommentServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/comment/CommentServiceTest.java)
 
 验证评论系统功能，包括添加评论/回复、分页查询、删除级联、点赞 toggle 和评论数统计。
 
@@ -114,7 +114,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoCreateServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/VideoCreateServiceTest.java)
+## [VideoCreateServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoCreateServiceTest.java)
 
 验证视频创建流程，包括 USER_UPLOAD 和 YOUTUBE 两种类型的创建，以及参数校验逻辑。
 
@@ -142,7 +142,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [VideoReadyServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/VideoReadyServiceTest.java)
+## [VideoReadyServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/VideoReadyServiceTest.java)
 
 验证视频就绪事件处理，包括存储降级和通知发送逻辑。
 
@@ -155,7 +155,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [LinkServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/LinkServiceTest.java)
+## [LinkServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/LinkServiceTest.java)
 
 验证文件去重链接功能，基于 MD5 判断源视频是否可复用，避免重复存储。
 
@@ -173,7 +173,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [YoutubeServiceTest](../../video/src/test/java/com/github/makewheels/video2022/video/YoutubeServiceTest.java)
+## [YoutubeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/video/YoutubeServiceTest.java)
 
 验证 YouTube 视频集成，包括 URL 解析、视频信息获取和文件传输。
 
@@ -190,7 +190,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [WatchServiceTest](../../video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
+## [WatchServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
 
 验证观看记录功能，包括观看计数、重复观看处理和观看记录清理。
 

--- a/docs/测试/3-文件与存储测试.md
+++ b/docs/测试/3-文件与存储测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [FileServiceTest](../../video/src/test/java/com/github/makewheels/video2022/file/FileServiceTest.java)
+## [FileServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/file/FileServiceTest.java)
 
 验证视频文件的创建、查询、上传完成、删除等文件生命周期操作。
 
@@ -37,7 +37,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [FileAccessLogServiceTest](../../video/src/test/java/com/github/makewheels/video2022/file/FileAccessLogServiceTest.java)
+## [FileAccessLogServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/file/FileAccessLogServiceTest.java)
 
 验证文件访问日志记录和关联费用生成功能。
 
@@ -51,7 +51,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [Md5CfServiceTest](../../video/src/test/java/com/github/makewheels/video2022/file/Md5CfServiceTest.java)
+## [Md5CfServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/file/Md5CfServiceTest.java)
 
 验证通过云函数获取 OSS 对象 MD5 值的功能，支持单文件和批量操作。
 
@@ -64,7 +64,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [OssServiceTest](../../video/src/test/java/com/github/makewheels/video2022/oss/OssServiceTest.java)
+## [OssServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/oss/OssServiceTest.java)
 
 验证阿里云 OSS 对象存储的核心操作，包括存在性检查、对象获取、预签名 URL、分页列表、删除、ACL 和存储类型修改。
 
@@ -84,7 +84,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [OssPathUtilTest](../../video/src/test/java/com/github/makewheels/video2022/utils/OssPathUtilTest.java)
+## [OssPathUtilTest](/server/video/src/test/java/com/github/makewheels/video2022/utils/OssPathUtilTest.java)
 
 验证 OSS 路径生成工具类，确保视频、封面、原始文件、转码、M3U8 等路径格式正确。
 

--- a/docs/测试/3-文件与存储测试.md
+++ b/docs/测试/3-文件与存储测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [FileServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/file/FileServiceTest.java)
+## [FileServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/file/FileServiceTest.java)
 
 验证视频文件的创建、查询、上传完成、删除等文件生命周期操作。
 
@@ -37,7 +37,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [FileAccessLogServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/file/FileAccessLogServiceTest.java)
+## [FileAccessLogServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/file/FileAccessLogServiceTest.java)
 
 验证文件访问日志记录和关联费用生成功能。
 
@@ -51,7 +51,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [Md5CfServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/file/Md5CfServiceTest.java)
+## [Md5CfServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/file/Md5CfServiceTest.java)
 
 验证通过云函数获取 OSS 对象 MD5 值的功能，支持单文件和批量操作。
 
@@ -64,7 +64,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [OssServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/oss/OssServiceTest.java)
+## [OssServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/oss/OssServiceTest.java)
 
 验证阿里云 OSS 对象存储的核心操作，包括存在性检查、对象获取、预签名 URL、分页列表、删除、ACL 和存储类型修改。
 
@@ -84,7 +84,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [OssPathUtilTest](/server/video/src/test/java/com/github/makewheels/video2022/utils/OssPathUtilTest.java)
+## [OssPathUtilTest](../../server/video/src/test/java/com/github/makewheels/video2022/utils/OssPathUtilTest.java)
 
 验证 OSS 路径生成工具类，确保视频、封面、原始文件、转码、M3U8 等路径格式正确。
 

--- a/docs/测试/4-财务模块测试.md
+++ b/docs/测试/4-财务模块测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [BillingServiceTest](../../video/src/test/java/com/github/makewheels/video2022/finance/BillingServiceTest.java)
+## [BillingServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/BillingServiceTest.java)
 
 验证账单创建的完整流程，包括 OSS 访问费用和转码费用的生成、价格计算和账单汇总。
 
@@ -42,7 +42,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [WalletServiceTest](../../video/src/test/java/com/github/makewheels/video2022/finance/WalletServiceTest.java)
+## [WalletServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/WalletServiceTest.java)
 
 验证钱包的创建、查询和余额变动功能。
 
@@ -63,7 +63,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [TransactionServiceTest](../../video/src/test/java/com/github/makewheels/video2022/finance/TransactionServiceTest.java)
+## [TransactionServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/TransactionServiceTest.java)
 
 验证交易记录创建、钱包扣款和账单状态更新的联动逻辑。
 
@@ -80,7 +80,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [UnitPriceServiceTest](../../video/src/test/java/com/github/makewheels/video2022/finance/UnitPriceServiceTest.java)
+## [UnitPriceServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/UnitPriceServiceTest.java)
 
 验证 OSS 访问单价的时段策略，低峰（00:00–07:59）¥0.25/GB，高峰（08:00–23:59）¥0.50/GB。
 
@@ -98,7 +98,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [OssAccessFeeServiceTest](../../video/src/test/java/com/github/makewheels/video2022/finance/OssAccessFeeServiceTest.java)
+## [OssAccessFeeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/OssAccessFeeServiceTest.java)
 
 验证 OSS 访问费用的创建和账单生成功能。
 

--- a/docs/测试/4-财务模块测试.md
+++ b/docs/测试/4-财务模块测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [BillingServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/BillingServiceTest.java)
+## [BillingServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/finance/BillingServiceTest.java)
 
 验证账单创建的完整流程，包括 OSS 访问费用和转码费用的生成、价格计算和账单汇总。
 
@@ -42,7 +42,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [WalletServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/WalletServiceTest.java)
+## [WalletServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/finance/WalletServiceTest.java)
 
 验证钱包的创建、查询和余额变动功能。
 
@@ -63,7 +63,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [TransactionServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/TransactionServiceTest.java)
+## [TransactionServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/finance/TransactionServiceTest.java)
 
 验证交易记录创建、钱包扣款和账单状态更新的联动逻辑。
 
@@ -80,7 +80,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [UnitPriceServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/UnitPriceServiceTest.java)
+## [UnitPriceServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/finance/UnitPriceServiceTest.java)
 
 验证 OSS 访问单价的时段策略，低峰（00:00–07:59）¥0.25/GB，高峰（08:00–23:59）¥0.50/GB。
 
@@ -98,7 +98,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [OssAccessFeeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/finance/OssAccessFeeServiceTest.java)
+## [OssAccessFeeServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/finance/OssAccessFeeServiceTest.java)
 
 验证 OSS 访问费用的创建和账单生成功能。
 

--- a/docs/测试/5-播放与统计测试.md
+++ b/docs/测试/5-播放与统计测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [WatchServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
+## [WatchServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
 
 验证观看日志记录、观看计数、观看信息查询、M3U8 播放列表生成等播放核心功能。
 
@@ -38,7 +38,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [HeartbeatProgressTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/HeartbeatProgressTest.java)
+## [HeartbeatProgressTest](../../server/video/src/test/java/com/github/makewheels/video2022/watch/HeartbeatProgressTest.java)
 
 验证播放器心跳上报和观看进度跟踪功能，包括 PLAYING/PAUSED 状态处理和多观看者隔离。
 
@@ -56,7 +56,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [StatisticsServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/etc/statistics/StatisticsServiceTest.java)
+## [StatisticsServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/etc/statistics/StatisticsServiceTest.java)
 
 验证流量统计功能，包括 Echarts 图表数据转换和流量聚合。
 
@@ -74,7 +74,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [PlaybackServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/PlaybackServiceTest.java)
+## [PlaybackServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/watch/PlaybackServiceTest.java)
 
 验证播放会话生命周期管理，包括会话创建、心跳更新、退出记录和完整生命周期。
 

--- a/docs/测试/5-播放与统计测试.md
+++ b/docs/测试/5-播放与统计测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [WatchServiceTest](../../video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
+## [WatchServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/WatchServiceTest.java)
 
 验证观看日志记录、观看计数、观看信息查询、M3U8 播放列表生成等播放核心功能。
 
@@ -38,7 +38,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [HeartbeatProgressTest](../../video/src/test/java/com/github/makewheels/video2022/watch/HeartbeatProgressTest.java)
+## [HeartbeatProgressTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/HeartbeatProgressTest.java)
 
 验证播放器心跳上报和观看进度跟踪功能，包括 PLAYING/PAUSED 状态处理和多观看者隔离。
 
@@ -56,7 +56,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [StatisticsServiceTest](../../video/src/test/java/com/github/makewheels/video2022/etc/statistics/StatisticsServiceTest.java)
+## [StatisticsServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/etc/statistics/StatisticsServiceTest.java)
 
 验证流量统计功能，包括 Echarts 图表数据转换和流量聚合。
 
@@ -74,7 +74,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [PlaybackServiceTest](../../video/src/test/java/com/github/makewheels/video2022/watch/PlaybackServiceTest.java)
+## [PlaybackServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/watch/PlaybackServiceTest.java)
 
 验证播放会话生命周期管理，包括会话创建、心跳更新、退出记录和完整生命周期。
 

--- a/docs/测试/6-播放列表测试.md
+++ b/docs/测试/6-播放列表测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [PlaylistServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/playlist/PlaylistServiceTest.java)
+## [PlaylistServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/playlist/PlaylistServiceTest.java)
 
 验证播放列表的创建、更新、删除、恢复、视频管理、分页查询和权限控制。
 

--- a/docs/测试/6-播放列表测试.md
+++ b/docs/测试/6-播放列表测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [PlaylistServiceTest](../../video/src/test/java/com/github/makewheels/video2022/playlist/PlaylistServiceTest.java)
+## [PlaylistServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/playlist/PlaylistServiceTest.java)
 
 验证播放列表的创建、更新、删除、恢复、视频管理、分页查询和权限控制。
 

--- a/docs/测试/7-封面与转码测试.md
+++ b/docs/测试/7-封面与转码测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CoverServiceTest](../../video/src/test/java/com/github/makewheels/video2022/cover/CoverServiceTest.java)
+## [CoverServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/cover/CoverServiceTest.java)
 
 验证视频封面的创建流程，包括阿里云截图任务提交、YouTube 封面提取、封面替换和回调处理。
 
@@ -40,7 +40,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [TranscodeCallbackServiceTest](../../video/src/test/java/com/github/makewheels/video2022/transcode/TranscodeCallbackServiceTest.java)
+## [TranscodeCallbackServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/transcode/TranscodeCallbackServiceTest.java)
 
 验证转码完成回调处理，包括视频就绪判断、M3U8 解析、TS 分片文件创建和比特率计算。
 
@@ -58,7 +58,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [AliyunMpsServiceTest](../../video/src/test/java/com/github/makewheels/video2022/transcode/AliyunMpsServiceTest.java)
+## [AliyunMpsServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/transcode/AliyunMpsServiceTest.java)
 
 验证阿里云媒体处理服务（MPS）的 API 调用，包括转码任务提交、模板选择和截图任务。
 
@@ -78,7 +78,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CloudFunctionTranscodeServiceTest](../../video/src/test/java/com/github/makewheels/video2022/transcode/CloudFunctionTranscodeServiceTest.java)
+## [CloudFunctionTranscodeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/transcode/CloudFunctionTranscodeServiceTest.java)
 
 验证阿里云函数计算转码服务的请求构建和调用。
 

--- a/docs/测试/7-封面与转码测试.md
+++ b/docs/测试/7-封面与转码测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CoverServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/cover/CoverServiceTest.java)
+## [CoverServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/cover/CoverServiceTest.java)
 
 验证视频封面的创建流程，包括阿里云截图任务提交、YouTube 封面提取、封面替换和回调处理。
 
@@ -40,7 +40,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [TranscodeCallbackServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/transcode/TranscodeCallbackServiceTest.java)
+## [TranscodeCallbackServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/transcode/TranscodeCallbackServiceTest.java)
 
 验证转码完成回调处理，包括视频就绪判断、M3U8 解析、TS 分片文件创建和比特率计算。
 
@@ -58,7 +58,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [AliyunMpsServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/transcode/AliyunMpsServiceTest.java)
+## [AliyunMpsServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/transcode/AliyunMpsServiceTest.java)
 
 验证阿里云媒体处理服务（MPS）的 API 调用，包括转码任务提交、模板选择和截图任务。
 
@@ -78,7 +78,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CloudFunctionTranscodeServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/transcode/CloudFunctionTranscodeServiceTest.java)
+## [CloudFunctionTranscodeServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/transcode/CloudFunctionTranscodeServiceTest.java)
 
 验证阿里云函数计算转码服务的请求构建和调用。
 

--- a/docs/测试/8-基础设施测试.md
+++ b/docs/测试/8-基础设施测试.md
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CheckServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/etc/check/CheckServiceTest.java)
+## [CheckServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/etc/check/CheckServiceTest.java)
 
 参数校验服务，包含 24 个嵌套测试类，共 79 个测试用例。覆盖用户、视频、文件、播放列表的存在性、归属、状态等校验。
 
@@ -206,7 +206,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [IpServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/utils/IpServiceTest.java)
+## [IpServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/utils/IpServiceTest.java)
 
 验证 IP 地理定位服务（基于 MongoDB 的 IpCache 缓存），包括缓存命中/未命中、IPv6 Key 规范化和结果扁平化。
 
@@ -219,7 +219,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [IdServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/utils/IdServiceTest.java)
+## [IdServiceTest](../../server/video/src/test/java/com/github/makewheels/video2022/utils/IdServiceTest.java)
 
 验证 ID 生成服务的格式、前缀和唯一性。
 
@@ -238,7 +238,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [SmokeTest](/server/video/src/test/java/com/github/makewheels/video2022/SmokeTest.java)
+## [SmokeTest](../../server/video/src/test/java/com/github/makewheels/video2022/SmokeTest.java)
 
 最小化冒烟测试，验证 Spring 上下文能够正常加载。
 
@@ -248,7 +248,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [UploadFlowTest](/server/video/src/test/java/com/github/makewheels/video2022/scenario/UploadFlowTest.java)
+## [UploadFlowTest](../../server/video/src/test/java/com/github/makewheels/video2022/scenario/UploadFlowTest.java)
 
 完整上传场景测试，验证从创建视频到上传完成的全流程。
 

--- a/docs/测试/8-基础设施测试.md
+++ b/docs/测试/8-基础设施测试.md
@@ -1,9 +1,9 @@
 # 基础设施测试
 
-基础设施模块覆盖参数校验服务（CheckService）、Redis 操作、IP 定位、ID 生成等基础能力，以及冒烟测试和上传场景测试。其中 CheckService 包含 24 个内部测试类，是项目中测试用例最多的文件。
+基础设施模块覆盖参数校验服务（CheckService）、IP 定位、ID 生成等基础能力，以及冒烟测试和上传场景测试。其中 CheckService 包含 24 个内部测试类，是项目中测试用例最多的文件。
 
-- **测试文件数**：8
-- **测试用例数**：115
+- **测试文件数**：5
+- **测试用例数**：95
 
 ## 运行方式
 
@@ -16,7 +16,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [CheckServiceTest](../../video/src/test/java/com/github/makewheels/video2022/etc/check/CheckServiceTest.java)
+## [CheckServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/etc/check/CheckServiceTest.java)
 
 参数校验服务，包含 24 个嵌套测试类，共 79 个测试用例。覆盖用户、视频、文件、播放列表的存在性、归属、状态等校验。
 
@@ -206,38 +206,20 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [RedisServiceTest](../../video/src/test/java/com/github/makewheels/video2022/etc/redis/RedisServiceTest.java)
+## [IpServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/utils/IpServiceTest.java)
 
-验证 Redis 操作封装，包括字符串存取、JSON 解析、删除和 TTL 过期。
-
-| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
-|---|---------|------|---------|------|---------|---------|
-| 1 | `set_andGet_shouldStoreAndRetrieveValue` | 存取字符串 | Redis 清空 | set "hello" 1分钟 TTL，get | value = "hello"，set 返回 true | 基本存取 |
-| 2 | `get_withNonExistentKey_shouldReturnNull` | 不存在的 Key | Key 不存在 | get | 返回 null | 缺失 key 处理 |
-| 3 | `get_withNullKey_shouldReturnNull` | Null Key | Key = null | get(null) | 返回 null | Null 安全 |
-| 4 | `getForJSONObject_shouldParseStoredJson` | JSON 解析 | 存储含 name/count 的 JSON | 调用 `getForJSONObject` | 解析正确：name="test"，count=42 | JSON 解析 |
-| 5 | `getForJSONObject_withNonExistentKey_shouldReturnNull` | 不存在 Key 的 JSON 查询 | Key 不存在 | 调用方法 | 返回 null | 缺失处理 |
-| 6 | `del_singleKey_shouldRemoveValue` | 删除单个 Key | Key 有值 | 删除后 get | 值为 null | 单 key 删除 |
-| 7 | `del_multipleKeys_shouldRemoveAllValues` | 批量删除 | 两个 Key 有值 | 批量删除 | 两个均为 null | 批量删除 |
-| 8 | `del_withNullKey_shouldNotThrow` | 删除 Null Key | null 数组 | del(null) | 不抛异常 | Null 安全 |
-| 9 | `set_withShortTtl_shouldExpire` | TTL 过期 | 设 1 秒 TTL | 等待 1.5 秒 | 立即可查到，过期后为 null | TTL 过期机制 |
-
----
-
-## [IpServiceTest](../../video/src/test/java/com/github/makewheels/video2022/utils/IpServiceTest.java)
-
-验证 IP 地理定位服务，包括 Redis 缓存和 IPv6 处理。
+验证 IP 地理定位服务（基于 MongoDB 的 IpCache 缓存），包括缓存命中/未命中、IPv6 Key 规范化和结果扁平化。
 
 | # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
 |---|---------|------|---------|------|---------|---------|
-| 1 | `getIpWithRedis_cacheHit_shouldReturnCachedValue` | 缓存命中 | IP 数据在 Redis | 查询 | 返回缓存值，不调用 set() | 缓存命中路径 |
-| 2 | `getIpWithRedis_cacheMiss_shouldCallApiAndCache` | 缓存未命中 | 无缓存，Mock HTTP API | 查询 | 调用外部 API，返回解析结果（nation="中国"，province="香港特别行政区"），缓存 6 小时 TTL | API 回退与缓存 |
-| 3 | `getIpWithRedis_ipv6WithColons_shouldReplaceColonsInRedisKey` | IPv6 处理 | IPv6 "2001:db8::1" | 查询 | Redis Key 中冒号替换为下划线："2001_db8__1" | IPv6 Key 规范 |
-| 4 | `getIpWithRedis_cacheMiss_shouldFlattenResultField` | 结果扁平化 | API 返回嵌套 "result" 对象 | 查询 | 移除嵌套 "result"，字段提升到顶层（en_short="CN"，lat=22.27628） | 结果扁平化 |
+| 1 | `getIpInfo_cacheHit_shouldReturnCachedValue` | 缓存命中 | IpCache 已在 MongoDB | `getIpInfo(ip)` | 返回缓存值（nation="中国"），不调用 save() | 缓存命中路径 |
+| 2 | `getIpInfo_cacheMiss_shouldCallApiAndCache` | 缓存未命中 | 无缓存，Mock HTTP API | `getIpInfo(ip)` | 调用外部 API，解析结果（nation="中国"，province="香港特别行政区"）并 save 到 MongoDB | API 回退与缓存 |
+| 3 | `getIpInfo_ipv6WithColons_shouldReplaceColonsInCacheKey` | IPv6 处理 | IpCache key="2001_db8__1" | `getIpInfo("2001:db8::1")` | 缓存 Key 中冒号替换为下划线："2001_db8__1" | CacheKey 规范化 |
+| 4 | `getIpInfo_cacheMiss_shouldFlattenResultField` | 结果扁平化 | API 返回嵌套 "result" 对象 | `getIpInfo(ip)` | 移除嵌套 "result"，字段提升到顶层（en_short="CN"，lat=22.27628） | 结果扁平化 |
 
 ---
 
-## [IdServiceTest](../../video/src/test/java/com/github/makewheels/video2022/utils/IdServiceTest.java)
+## [IdServiceTest](/server/video/src/test/java/com/github/makewheels/video2022/utils/IdServiceTest.java)
 
 验证 ID 生成服务的格式、前缀和唯一性。
 
@@ -256,7 +238,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [SmokeTest](../../video/src/test/java/com/github/makewheels/video2022/SmokeTest.java)
+## [SmokeTest](/server/video/src/test/java/com/github/makewheels/video2022/SmokeTest.java)
 
 最小化冒烟测试，验证 Spring 上下文能够正常加载。
 
@@ -266,7 +248,7 @@ export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Psprin
 
 ---
 
-## [UploadFlowTest](../../video/src/test/java/com/github/makewheels/video2022/scenario/UploadFlowTest.java)
+## [UploadFlowTest](/server/video/src/test/java/com/github/makewheels/video2022/scenario/UploadFlowTest.java)
 
 完整上传场景测试，验证从创建视频到上传完成的全流程。
 

--- a/docs/测试/9-E2E端到端测试.md
+++ b/docs/测试/9-E2E端到端测试.md
@@ -1,82 +1,172 @@
-# E2E 端到端测试
+# API 端到端测试
 
-E2E 测试通过 HTTP 请求调用真实 API 接口，验证从登录到视频上传、修改、观看、播放列表管理的完整业务流程。测试使用 RestTemplate 发起请求，连接真实的 MongoDB 和 Redis，确保各模块集成正确。
+`test/api/` 下的 Python + requests 测试，通过 HTTP 调用真实运行的后端接口，覆盖登录认证、用户资料、订阅、视频上传/修改/观看/删除、搜索、播放列表以及统一错误响应等业务流程。测试连接真实的后端服务（默认 `http://localhost:5022`）和 MongoDB，验证端到端的接口契约与权限控制。
 
-- **测试文件数**：5
-- **测试用例数**：22
+- **测试文件数**：11
+- **测试用例数**：75（含参数化展开）
+
+> 历史说明：这里原本是 Java 内嵌的 `com.github.makewheels.video2022.e2e.*` 测试，前后端分离重构（`f8c5296e`）后已迁移到本目录的 Python 测试。
 
 ## 运行方式
 
 ```bash
-# 运行全部 E2E 测试
-export $(grep -v '^#' .env | grep -v '^$' | xargs) && mvn test -pl video -Pspringboot \
-  -Dtest="com.github.makewheels.video2022.e2e.*" \
-  -Dlog4j.configuration=file:///tmp/log4j.properties
+# 需先启动后端服务（默认 localhost:5022）
+python3 -m pytest test/api
+
+# 只跑标记为 api 的用例
+python3 -m pytest test/api -m api
 ```
 
 ---
 
-## [LoginE2ETest](../../video/src/test/java/com/github/makewheels/video2022/e2e/LoginE2ETest.java)
+## [test_login.py](/test/api/test_login.py)
 
-验证完整的手机号登录流程，包括验证码发送、Token 校验、无效凭证拒绝等。
+验证手机号验证码登录主流程：登录拿 token、token 校验、getUserByToken 查询、重新登录刷新 token，以及非法手机号/错误验证码的拒绝。使用独立手机号 `19900009999`，避免影响会话级 `auth_token` fixture。
 
 | # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
 |---|---------|------|---------|------|---------|---------|
-| 1 | `testLoginFlowAndTokenValidation` | 完整登录验证 | 通过 baseSetUp 登录 | 验证 token/userId 上下文；查询 MongoDB 用户；携带 token 调用受保护 API | MongoDB 中用户存在，token 匹配，受保护 API 返回 200 & code=0 | 登录创建 Token 并允许认证访问 |
-| 2 | `testInvalidTokenRedirectsToLogin` | 无效 Token 重定向 | 无 | 携带伪造 token 访问受保护端点 | RestTemplate 跟随 302 重定向，最终返回登录页 | 无效 Token 拦截与重定向 |
-| 3 | `testGetUserByToken` | Token 查询用户 | 已有有效 token | GET /user/getUserByToken?token=<token> | code=0，响应含 id、token、phone | Token 查询 API |
-| 4 | `testReLoginRefreshesToken` | 重新登录刷新 Token | 已有有效 token | 同一手机号再次调用 login() | 新 token ≠ 旧 token，userId 不变 | Token 刷新机制 |
-| 5 | `login_invalidPhoneFormat_shouldReturnError` | 无效手机号格式 | 无 | GET /user/requestVerificationCode?phone=123 | 返回非 0 code 或 HTTP 错误 | 手机号格式校验 |
-| 6 | `login_emptyPhone_shouldReturnError` | 空手机号 | 无 | GET /user/requestVerificationCode?phone= | 返回 4xx 或非 0 code | 空值校验 |
-| 7 | `login_wrongVerificationCode_shouldFail` | 错误验证码 | 已发送验证码 | 提交 code=999999 | code ≠ 0 或 HTTP 错误 | 错误验证码拒绝 |
+| 1 | `test_login_flow_and_token_validation` | 登录后访问受保护接口 | 测试手机号 | 登录拿 token，携带 token 调 `/video/getMyVideoList` | 登录 code=0，受保护接口 200 且 code=0 | 登录创建 token 并允许认证访问 |
+| 2 | `test_invalid_token_returns_error` | 伪造 token | 无 | 携带 `invalid_token_xxx` 调受保护接口 | 返回 code≠0 | 无效 token 拒绝 |
+| 3 | `test_get_user_by_token` | Token 查询用户 | 已登录拿 token | GET `/user/getUserByToken?token=` | code=0，data 含 id/token/phone | Token 查询 API |
+| 4 | `test_relogin_refreshes_token` | 重新登录刷新 token | 已登录 | 同一手机号再次 login | userId 不变，token 刷新 | Token 刷新机制 |
+| 5 | `test_bad_phone_returns_error[invalid_phone_format]` | 非法手机号格式 | 无 | submitVerificationCode，phone="123" | code≠0 | 手机号格式校验 |
+| 6 | `test_bad_phone_returns_error[empty_phone]` | 空手机号 | 无 | submitVerificationCode，phone="" | code≠0 | 空值校验 |
+| 7 | `test_wrong_verification_code` | 错误验证码 | 已发送验证码 | 提交 code="999" | code≠0 | 错误验证码拒绝 |
 
 ---
 
-## [VideoUploadE2ETest](../../video/src/test/java/com/github/makewheels/video2022/e2e/VideoUploadE2ETest.java)
+## [test_auth_session.py](/test/api/test_auth_session.py)
 
-验证视频创建和上传的完整流程，包括 OSS 凭证获取和参数校验。
+验证 token 鉴权拦截：无效 / 缺失 / 空 token 均返回 401，有效 token 可正常访问；并对全部受保护端点逐个验证未认证访问被拦截。
 
 | # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
 |---|---------|------|---------|------|---------|---------|
-| 1 | `testCreateAndUploadVideo` | 完整上传流程 | 已认证用户 | 1) POST /video/create → 2) GET /file/getUploadCredentials → 3) STS 上传到 OSS → 4) GET /file/uploadFinish | Video 和 File 在 MongoDB 中，File.fileStatus=READY，OSS 对象存在 | 创建→凭证→上传→通知→验证 |
-| 2 | `testCreateVideoAppearsInMyVideoList` | 视频出现在列表 | 已认证用户 | 创建视频后 GET /video/getMyVideoList?skip=0&limit=10 | code=0，新 videoId 在 data 数组中 | 创建后立即可见 |
-| 3 | `createVideo_missingRequiredFields_shouldReturnError` | 缺失必填字段 | 无 | POST /video/create 缺少 rawFilename/size | code ≠ 0 或抛异常 | 必填字段校验 |
-| 4 | `createVideo_invalidVideoType_shouldReturnError` | 无效视频类型 | 无 | POST /video/create，videoType=INVALID_TYPE | code ≠ 0 或抛异常 | 枚举校验 |
+| 1 | `test_invalid_token_returns_401` | 伪造 token | 无 | 携带 `fake-token-abc123` 调受保护接口 | HTTP 401，body.code=401 | 无效 token 拦截 |
+| 2 | `test_no_token_returns_401` | 不带 token | 无 | 不携带 token 头请求 | HTTP 401，body.code=401 | 缺失 token 拦截 |
+| 3 | `test_empty_token_returns_401` | 空字符串 token | 无 | 携带 `token=""` 请求 | HTTP 401，body.code=401 | 空 token 拦截 |
+| 4 | `test_valid_token_accesses_protected` | 有效 token | 已登录 | 携带真实 token 调 `/video/getMyVideoList` | HTTP 200，code=0 | 认证访问放行 |
+| 5 | `test_all_protected_endpoints_require_auth`（参数化 21 个端点） | 全量受保护端点 | 无 | 未带 token 依次访问 video/file/playlist/videoLike/comment/user/subscription 等 21 个端点 | 每个端点均返回 HTTP 401 | 受保护端点全覆盖鉴权 |
 
 ---
 
-## [VideoModifyE2ETest](../../video/src/test/java/com/github/makewheels/video2022/e2e/VideoModifyE2ETest.java)
+## [test_user_profile.py](/test/api/test_user_profile.py)
 
-验证视频信息修改的权限控制和持久化。
+验证用户资料管理：getMyProfile、updateProfile（昵称/简介及长度校验）、getChannel 频道信息，以及未认证访问拒绝。
 
 | # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
 |---|---------|------|---------|------|---------|---------|
-| 1 | `testUpdateVideoInfo` | 更新视频信息 | 用户创建了视频 | POST /video/updateInfo 修改 title/description → API 验证 → MongoDB 验证 → GET /video/getVideoDetail 验证 | 三处均返回更新后的值 | 更新持久化与 API 一致性 |
-| 2 | `testUpdateVideoByOtherUserFails` | 非拥有者修改被拒 | 用户 A 创建视频，用户 B 登录 | 用户 B 尝试 POST /video/updateInfo | code ≠ 0，MongoDB 中视频未变 | 所有者权限校验 |
+| 1 | `test_get_my_profile` | 获取本人资料 | 已认证 | GET `/user/getMyProfile` | code=0，data 含 id/phone | 资料查询 |
+| 2 | `test_update_profile_nickname` | 更新昵称/简介 | 已认证 | POST `/user/updateProfile`，再查询验证 | code=0，nickname/bio 已更新 | 资料更新持久化 |
+| 3 | `test_update_profile_nickname_too_long` | 昵称超长 | 已认证 | nickname 31 字符 | code≠0 | 昵称长度上限（30） |
+| 4 | `test_update_profile_bio_too_long` | 简介超长 | 已认证 | bio 201 字符 | code≠0 | 简介长度上限（200） |
+| 5 | `test_get_channel` | 获取频道信息 | 已认证 | GET `/user/getChannel?userId=` | code=0，含 subscriberCount/videoCount | 频道信息 API |
+| 6 | `test_get_channel_nonexistent` | 不存在的用户频道 | 无 | 查询不存在的 userId | code≠0 | 缺失用户处理 |
+| 7 | `test_update_profile_requires_auth` | 未认证更新 | 无 | 不带 token POST updateProfile | code≠0 | 鉴权校验 |
 
 ---
 
-## [VideoWatchE2ETest](../../video/src/test/java/com/github/makewheels/video2022/e2e/VideoWatchE2ETest.java)
+## [test_subscription.py](/test/api/test_subscription.py)
 
-验证视频观看相关的 API 端点，包括观看信息获取和页面访问。
+验证频道订阅：禁止订阅自己、订阅/取消订阅及状态查询、订阅不存在频道、我的订阅列表、未认证拒绝。
 
 | # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
 |---|---------|------|---------|------|---------|---------|
-| 1 | `testGetWatchInfo` | 获取观看信息 | 视频已创建，有 watchId | GET /watchController/getWatchInfo?watchId=<id> | HTTP 200，响应为有效 JSON 含 code 字段 | 观看信息 API |
-| 2 | `testWatchPageAccessible` | 观看页面可访问 | 视频已创建，有 watchId | GET /watch?v=<watchId> | HTTP 200，响应含 HTML 标签 | 播放页面渲染 |
-| 3 | `testGetVideoDetail` | 获取视频详情 | 视频已创建 | GET /video/getVideoDetail?videoId=<id> | code=0，data 含 id、type、watchId、watchUrl | 视频详情 API |
-| 4 | `testGetWatchInfo_nonExistentWatchId_shouldReturnError` | 不存在的 watchId | 无 | GET /watchController/getWatchInfo?watchId=non-existent-id | code ≠ 0 | 无效 watchId 错误 |
-| 5 | `testGetVideoDetail_nonExistentVideoId_shouldReturnError` | 不存在的 videoId | 无 | GET /video/getVideoDetail?videoId=non-existent-id | code ≠ 0 | 无效 videoId 错误 |
+| 1 | `test_cannot_subscribe_self` | 订阅自己 | 已认证 | subscribe channelUserId=自己 | code≠0 | 禁止自订阅 |
+| 2 | `test_subscribe_and_unsubscribe` | 订阅→取消完整流程 | 两个用户 | subscribe → getStatus=true → unsubscribe → getStatus=false | 各步骤 code=0，状态正确翻转 | 订阅状态机 |
+| 3 | `test_subscribe_nonexistent_channel` | 订阅不存在频道 | 无 | subscribe 无效 channelUserId | code≠0 | 缺失频道处理 |
+| 4 | `test_get_my_subscriptions` | 我的订阅列表 | 已认证 | getMySubscriptions skip/limit | code=0，data 为 list | 订阅列表分页 |
+| 5 | `test_subscription_requires_auth` | 未认证订阅 | 无 | 不带 token subscribe | code≠0 | 鉴权校验 |
 
 ---
 
-## [PlaylistE2ETest](../../video/src/test/java/com/github/makewheels/video2022/e2e/PlaylistE2ETest.java)
+## [test_video_upload.py](/test/api/test_video_upload.py)
 
-验证播放列表创建和视频添加的 API 集成。
+验证视频创建：返回 videoId/fileId/watchUrl/watchId、创建后出现在我的视频列表、缺失必填字段拒绝、非法 videoType 处理。
 
 | # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
 |---|---------|------|---------|------|---------|---------|
-| 1 | `testCreatePlaylistAndAddVideo` | 创建列表并添加视频 | 已认证用户 | 1) 创建视频 → 2) POST /playlist/createPlaylist → 3) POST /playlist/addPlaylistItem | Playlist/PlayItem 在 MongoDB 中存在，PlayItem 引用视频 | 列表创建与视频添加 |
-| 2 | `testAddMultipleVideosToPlaylist` | 添加多个视频 | 已认证用户 | 创建 2 个视频 → 创建列表 → 添加两个 videoId | 2 个 PlayItem 文档，含相同 playlistId | 批量添加 |
-| 3 | `testCreatePlaylist_emptyName_shouldStillCreate` | 空标题创建 | 无 | POST /playlist/createPlaylist，title="" | 响应含 code 字段 | 空标题处理 |
-| 4 | `testCreatePlaylist_missingTitle_shouldStillCreate` | 缺少标题 | 无 | POST /playlist/createPlaylist 无 title 字段 | 响应含 code 字段 | 缺失标题处理 |
+| 1 | `test_create_video` | 创建视频 | 已认证 | POST `/video/create` | code=0，data 含 videoId/fileId/watchUrl/watchId | 创建返回字段 |
+| 2 | `test_create_video_appears_in_my_list` | 出现在列表 | 已认证 | 创建后 GET getMyVideoList | 新 videoId 在列表中 | 创建后即时可见 |
+| 3 | `test_create_video_missing_fields[missing-rawFilename]` | 缺 rawFilename | 无 | create 缺 rawFilename | code≠0 | 必填字段校验 |
+| 4 | `test_create_video_missing_fields[missing-size]` | 缺 size | 无 | create 缺 size | code≠0 | 必填字段校验 |
+| 5 | `test_create_video_missing_fields[empty-body]` | 空请求体 | 无 | create 空 body | code≠0 | 必填字段校验 |
+| 6 | `test_create_video_invalid_type` | 非法 videoType | 无 | create videoType=INVALID_TYPE | 响应含 code 字段 | 枚举校验容错 |
+
+---
+
+## [test_video_modify.py](/test/api/test_video_modify.py)
+
+验证视频信息修改的持久化与所有者权限控制。
+
+| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
+|---|---------|------|---------|------|---------|---------|
+| 1 | `test_update_video_info` | 更新标题/描述 | 用户已创建视频 | POST updateInfo，再 getVideoDetail 验证 | code=0，detail 返回更新后的 title/description | 更新持久化与一致性 |
+| 2 | `test_update_video_by_other_user_fails` | 非拥有者修改 | 用户 A 创建，用户 B 操作 | 用户 B POST updateInfo | code≠0 | 所有者权限校验 |
+
+---
+
+## [test_video_watch.py](/test/api/test_video_watch.py)
+
+验证观看相关接口：getWatchInfo、观看页面可访问、getVideoDetail，以及无效 watchId/videoId 的错误处理。
+
+| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
+|---|---------|------|---------|------|---------|---------|
+| 1 | `test_get_watch_info` | 获取观看信息 | 已创建视频，有 watchId | GET `/watchController/getWatchInfo?watchId=` | code=0，data 非空 | 观看信息 API |
+| 2 | `test_watch_page_accessible` | 观看页可访问 | 有 watchId | GET `/watch/{watchId}` | HTTP 200 | 播放页渲染 |
+| 3 | `test_get_video_detail` | 获取视频详情 | 已创建视频 | GET `/video/getVideoDetail?videoId=` | code=0，含 id/type/watchId | 视频详情 API |
+| 4 | `test_get_watch_info_nonexistent` | 无效 watchId | 无 | 查询不存在 watchId | code≠0 | 无效 watchId 错误 |
+| 5 | `test_get_video_detail_nonexistent` | 无效 videoId | 无 | 查询不存在 videoId | code≠0 | 无效 videoId 错误 |
+
+---
+
+## [test_video_delete.py](/test/api/test_video_delete.py)
+
+验证视频删除的权限控制：删除本人视频后不可访问、删除他人视频被拒、删除不存在视频报错、未认证删除返回 401。
+
+| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
+|---|---------|------|---------|------|---------|---------|
+| 1 | `test_delete_own_video` | 删除本人视频 | 用户已创建视频 | delete 后 getVideoDetail | 删除 code=0，再查 code≠0 | 删除主流程 |
+| 2 | `test_delete_other_user_video` | 删除他人视频 | 用户 A 创建，用户 B 操作 | 用户 B delete | code≠0 | 所有者权限校验 |
+| 3 | `test_delete_nonexistent_video` | 删除不存在视频 | 无 | delete 无效 videoId | code≠0 | 缺失视频处理 |
+| 4 | `test_delete_requires_auth` | 未认证删除 | 无 | 不带 token delete | HTTP 401 | 鉴权校验 |
+
+---
+
+## [test_search.py](/test/api/test_search.py)
+
+验证搜索接口：公开视频关键词搜索、我的视频搜索、空关键词、特殊（中文）字符不崩溃。
+
+| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
+|---|---------|------|---------|------|---------|---------|
+| 1 | `test_public_search_with_keyword` | 公开搜索 | 无 | GET `/video/getPublicVideoList?keyword=test` | code=0，data 含 list/total | 公开搜索 API |
+| 2 | `test_my_videos_search_with_keyword` | 我的视频搜索无结果 | 已认证 | getMyVideoList keyword=不存在词 | code=0，total=0 | 个人搜索过滤 |
+| 3 | `test_search_empty_keyword` | 空关键词 | 无 | keyword="" | code=0 | 空关键词容错 |
+| 4 | `test_search_special_characters` | 中文关键词 | 无 | keyword="中文" | code=0 | 特殊字符容错 |
+
+---
+
+## [test_playlist.py](/test/api/test_playlist.py)
+
+验证播放列表：创建列表并添加视频、批量添加多个视频、空标题/缺标题创建的容错。
+
+| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
+|---|---------|------|---------|------|---------|---------|
+| 1 | `test_create_playlist_and_add_video` | 创建并添加视频 | 已认证 | 创建视频 → createPlaylist → addPlaylistItem → getMyPlaylistByPage | 各步 code=0，列表中可见新 playlistId | 列表创建与添加 |
+| 2 | `test_add_multiple_videos` | 添加多个视频 | 已认证 | 创建 2 视频 → 建列表 → 批量添加 | code=0，列表中恰有 1 条匹配 playlistId | 批量添加 |
+| 3 | `test_create_playlist_empty_name` | 空标题创建 | 已认证 | createPlaylist title="" | 响应含 code 字段 | 空标题处理 |
+| 4 | `test_create_playlist_missing_title` | 缺标题创建 | 已认证 | createPlaylist 无 title | 响应含 code 字段 | 缺失标题处理 |
+
+---
+
+## [test_error_handling.py](/test/api/test_error_handling.py)
+
+验证各接口对不存在资源 / 非法入参的统一错误响应（code≠0）。
+
+| # | 测试方法 | 场景 | 前置条件 | 操作 | 期望结果 | 测试目标 |
+|---|---------|------|---------|------|---------|---------|
+| 1 | `test_nonexistent_video_detail` | 详情-不存在视频 | 无 | getVideoDetail 无效 videoId | code≠0 | 错误响应一致性 |
+| 2 | `test_delete_nonexistent_video` | 删除-不存在视频 | 无 | delete 无效 videoId | code≠0 | 错误响应一致性 |
+| 3 | `test_update_nonexistent_video` | 更新-不存在视频 | 无 | updateInfo 无效 id | code≠0 | 错误响应一致性 |
+| 4 | `test_get_status_nonexistent_video` | 状态-不存在视频 | 无 | getVideoStatus 无效 videoId | code≠0 | 错误响应一致性 |
+| 5 | `test_create_video_missing_fields` | 创建-空请求体 | 无 | create 空 body | code≠0 | 错误响应一致性 |
+| 6 | `test_comment_on_nonexistent_video` | 评论-不存在视频 | 无 | comment/add 无效 videoId | code≠0 | 错误响应一致性 |

--- a/docs/测试/9-E2E端到端测试.md
+++ b/docs/测试/9-E2E端到端测试.md
@@ -19,7 +19,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_login.py](/test/api/test_login.py)
+## [test_login.py](../../test/api/test_login.py)
 
 验证手机号验证码登录主流程：登录拿 token、token 校验、getUserByToken 查询、重新登录刷新 token，以及非法手机号/错误验证码的拒绝。使用独立手机号 `19900009999`，避免影响会话级 `auth_token` fixture。
 
@@ -35,7 +35,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_auth_session.py](/test/api/test_auth_session.py)
+## [test_auth_session.py](../../test/api/test_auth_session.py)
 
 验证 token 鉴权拦截：无效 / 缺失 / 空 token 均返回 401，有效 token 可正常访问；并对全部受保护端点逐个验证未认证访问被拦截。
 
@@ -49,7 +49,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_user_profile.py](/test/api/test_user_profile.py)
+## [test_user_profile.py](../../test/api/test_user_profile.py)
 
 验证用户资料管理：getMyProfile、updateProfile（昵称/简介及长度校验）、getChannel 频道信息，以及未认证访问拒绝。
 
@@ -65,7 +65,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_subscription.py](/test/api/test_subscription.py)
+## [test_subscription.py](../../test/api/test_subscription.py)
 
 验证频道订阅：禁止订阅自己、订阅/取消订阅及状态查询、订阅不存在频道、我的订阅列表、未认证拒绝。
 
@@ -79,7 +79,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_video_upload.py](/test/api/test_video_upload.py)
+## [test_video_upload.py](../../test/api/test_video_upload.py)
 
 验证视频创建：返回 videoId/fileId/watchUrl/watchId、创建后出现在我的视频列表、缺失必填字段拒绝、非法 videoType 处理。
 
@@ -94,7 +94,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_video_modify.py](/test/api/test_video_modify.py)
+## [test_video_modify.py](../../test/api/test_video_modify.py)
 
 验证视频信息修改的持久化与所有者权限控制。
 
@@ -105,7 +105,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_video_watch.py](/test/api/test_video_watch.py)
+## [test_video_watch.py](../../test/api/test_video_watch.py)
 
 验证观看相关接口：getWatchInfo、观看页面可访问、getVideoDetail，以及无效 watchId/videoId 的错误处理。
 
@@ -119,7 +119,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_video_delete.py](/test/api/test_video_delete.py)
+## [test_video_delete.py](../../test/api/test_video_delete.py)
 
 验证视频删除的权限控制：删除本人视频后不可访问、删除他人视频被拒、删除不存在视频报错、未认证删除返回 401。
 
@@ -132,7 +132,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_search.py](/test/api/test_search.py)
+## [test_search.py](../../test/api/test_search.py)
 
 验证搜索接口：公开视频关键词搜索、我的视频搜索、空关键词、特殊（中文）字符不崩溃。
 
@@ -145,7 +145,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_playlist.py](/test/api/test_playlist.py)
+## [test_playlist.py](../../test/api/test_playlist.py)
 
 验证播放列表：创建列表并添加视频、批量添加多个视频、空标题/缺标题创建的容错。
 
@@ -158,7 +158,7 @@ python3 -m pytest test/api -m api
 
 ---
 
-## [test_error_handling.py](/test/api/test_error_handling.py)
+## [test_error_handling.py](../../test/api/test_error_handling.py)
 
 验证各接口对不存在资源 / 非法入参的统一错误响应（code≠0）。
 

--- a/docs/测试/README.md
+++ b/docs/测试/README.md
@@ -14,12 +14,12 @@
 | 类型 | 目录 | 文件数 | 用例数 |
 |------|------|--------|--------|
 | Java 单元 / 集成测试 | `server/video/src/test/java` | 49 | 558 |
-| Python API E2E | `test/api` | 12 | 75 |
+| Python API E2E | `test/api` | 11 | 75 |
 | Python 浏览器 E2E | `test/browser` | 12 | 80 |
 | Web 单元测试 | `web/tests` | 12 | 38 |
 | CLI 单元测试 | `cli/tests` | 15 | 105 |
 | CLI 冒烟测试 | `test/cli` | 2 | 7 |
-| **合计** |  | **102** | **863** |
+| **合计** |  | **101** | **863** |
 
 ## 文档索引
 


### PR DESCRIPTION
## 背景

测试文档（`docs/测试/`）里指向测试类的链接全部失效，点击无法跳转。根因是历史重构后文档未同步：

- `backend/ → server/` 重命名，导致 `../../video/...` 链接少了 `server/` 前缀，**42 条链接全断**
- 移除 Redis、Java e2e 迁移到 Python `test/api`，部分文档指向已删除的类

## 改动

- **链接修复**：全部代码链接改为正确的相对路径 `../../server/...`、`../../test/...`，在 IDEA / VS Code / GitHub 均可点击跳转（曾尝试根绝对 `/server/...`，但 IDE 会当作文件系统根而无法跳转，故采用相对路径）
- **重写 `9-E2E端到端测试.md`**：原本记录已删除的 Java 内嵌 e2e，现改为 `test/api/` 的 11 个 Python 用例文件（75 用例，pytest 实测）
- **`8-基础设施测试.md`**：移除已删除的 `RedisServiceTest` 段；`IpServiceTest` 更新为 MongoDB 缓存（方法名 `getIpWithRedis_*` → `getIpInfo_*`）；统计修正 8 文件/115 用例 → 5 文件/95 用例
- **`README.md`**：`test/api` 文件数 12 → 11

## 校验

- 47 条链接目标逐一 `test -e` 校验，全部存在、可从各文档相对解析
- 无 `../../` 失效路径残留、无指向已删除类的引用

> 另：本地残留的 `backend/` 目录及散落的 Eclipse `.classpath`/`.project` 已清理（git 不跟踪，不在本 PR 内）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)