### PR TITLE
fix: 导航栏 E2E 测试同步新增的「AI 助手」链接

### DIFF
--- a/test/browser/test_navigation.py
+++ b/test/browser/test_navigation.py
@@ -4,7 +4,7 @@ NavBar structure (from NavBar.tsx):
 - header.page-header
   - Link.logo → "📹 Video" → /
   - form.nav-search with search input and button
-  - nav.nav-menu with nav-links: 首页(/), 我的视频(/my-videos), 上传(/upload), 统计(/statistics), YouTube(/youtube)
+  - nav.nav-menu with nav-links: 首页(/), 我的视频(/my-videos), 上传(/upload), AI 助手(/chat), 统计(/statistics), YouTube(/youtube)
   - .header-right with theme toggle and auth section
   - button.mobile-menu-btn (hamburger)
 - footer.page-footer with "Video Platform"
@@ -28,14 +28,14 @@ class TestNavBarStructure:
         assert "Video" in logo.inner_text()
 
     def test_nav_links_present(self, auth_page, base_url):
-        """All five nav links are present."""
+        """All six nav links are present."""
         auth_page.goto(base_url)
         nav = auth_page.locator("nav.nav-menu")
         nav.wait_for(timeout=BASE_TIMEOUT)
         links = nav.locator("a.nav-link")
-        assert links.count() == 5
-        labels = [links.nth(i).inner_text() for i in range(5)]
-        assert labels == ["首页", "我的视频", "上传", "统计", "YouTube"]
+        assert links.count() == 6
+        labels = [links.nth(i).inner_text() for i in range(6)]
+        assert labels == ["首页", "我的视频", "上传", "AI 助手", "统计", "YouTube"]
 
     def test_footer_visible(self, auth_page, base_url):
         """Footer with 'Video Platform' is visible."""


### PR DESCRIPTION
## 问题

浏览器 E2E `test_navigation.py::TestNavBarStructure::test_nav_links_present` 在 master 上失败：

```
assert links.count() == 6
AssertionError: assert 6 == 5
```

## 原因

`NavBar.tsx` 的导航项增加到 6 个（新增 `/chat`「AI 助手」），但测试仍硬编码期望 5 个、且 labels 列表未包含它。属于测试未跟上前端新增功能。

## 改动

- `test_nav_links_present`：期望数 5 → 6，labels 补入 `AI 助手`（按实际顺序插在「上传」与「统计」之间）
- 同步更新文件顶部描述导航结构的 docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)