### PR TITLE
feat: video-cli 新增 upload 命令与多环境 profile 配置

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,48 @@ pip install -e .
 ```bash
 video-cli --base-url http://localhost:5022  # 指定 API 地址
 video-cli --token <token>                   # 指定认证 token
+video-cli --profile prod                    # 指定 profile（local / prod / 自定义）
 video-cli --output table                    # 人类可读的表格输出
+```
+
+### 生产环境
+
+- API / 站点域名：`https://oneclick.video`
+- 视频 OSS：`video-2022-prod`（cn-beijing），上传走服务端下发的 STS 临时凭证，无需本机配 AK
+- 当前部署的短信验证码非生产校验，固定 `111` 可登录（先调发码接口建记录，再用 111 提交）
+
+```bash
+# 上传一个公开视频到生产（已配好 prod profile 的话）
+video-cli -p prod video upload --file ~/Downloads/xxx.mp4 --visibility PUBLIC
+
+# 确认是否已存在（按标题关键字搜自己的视频）
+video-cli -p prod video list --keyword 自我介绍
+```
+
+### 多环境 Profile
+
+配置文件 `~/.video-cli/config.json` 支持多个 profile，本地和生产**各存各的 base_url 和 token**，互不覆盖。内置 `local`（localhost:5022）和 `prod`（oneclick.video）两个名字的默认地址。
+
+```bash
+# 创建/切换默认环境（local、prod 自带默认地址，其它名字用 --base-url 指定）
+video-cli config use prod
+video-cli config use local
+video-cli config use staging --base-url https://staging.example.com
+
+# 登录会把 token 存到「当前」profile
+video-cli auth login --phone <手机号>             # 先发验证码
+video-cli auth login --phone <手机号> --code 111   # 提交，token 存入当前 profile
+
+# 查看所有 profile / 当前生效的
+video-cli config list
+
+# 单次指定环境（不改默认），或用环境变量 VIDEO_CLI_PROFILE
+video-cli -p local video list
+video-cli --profile prod video list
+
+# 给指定 profile 单独设置
+video-cli config set-token <token> --profile prod
+video-cli config set-base-url <url> --profile staging
 ```
 
 ### 认证
@@ -75,7 +116,12 @@ video-cli video update --id <videoId> --title "新标题" --visibility PUBLIC
 # 删除视频
 video-cli video delete --id <videoId>
 
-# 预创建视频（用于上传，默认 USER_UPLOAD）
+# 上传本地视频（一条命令走完整流程，推荐）
+# 内部流程：create → 取 OSS STS 凭证 → multipart 直传 OSS → uploadFinish → rawFileUploadFinish 触发转码
+video-cli video upload --file ~/Downloads/xxx.mp4
+video-cli video upload --file ~/Downloads/xxx.mp4 --title "标题" --visibility PUBLIC
+
+# 仅预创建视频元数据（拿 videoId/fileId，不上传字节；一般用 upload 即可）
 video-cli video create --file test.mp4
 video-cli video create --file test.mp4 --type USER_UPLOAD
 
@@ -211,7 +257,20 @@ video-cli share stats --short-code <shortCode>
 |------|------|
 | `VIDEO_CLI_BASE_URL` | API 基础 URL |
 | `VIDEO_CLI_TOKEN` | 认证 token |
+| `VIDEO_CLI_PROFILE` | 使用的 profile 名 |
 
 ## 配置文件
 
-登录后 token 保存在 `~/.video-cli/config.json`。
+`~/.video-cli/config.json`，多 profile 结构，每个 profile 各存 base_url 和 token：
+
+```json
+{
+  "current_profile": "prod",
+  "profiles": {
+    "local": { "base_url": "http://localhost:5022", "token": "..." },
+    "prod":  { "base_url": "https://oneclick.video", "token": "..." }
+  }
+}
+```
+
+旧版扁平结构（顶层 `base_url`/`token`）仍兼容，会按需自动迁移。

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,5 +1,6 @@
 click>=8.0
 requests>=2.28
 tabulate>=0.9
+oss2>=2.18
 pytest>=7.0
 responses>=0.23

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -10,6 +10,7 @@ setup(
         "click>=8.0",
         "requests>=2.28",
         "tabulate>=0.9",
+        "oss2>=2.18",
     ],
     extras_require={
         "test": ["pytest>=7.0", "pytest-xdist>=3.0", "responses>=0.23"],

--- a/cli/video_cli/commands/config.py
+++ b/cli/video_cli/commands/config.py
@@ -5,9 +5,12 @@ from ..config import (
     clear_config,
     clear_token,
     get_base_url,
+    get_current_profile,
     get_token,
+    list_profiles,
     set_base_url,
     set_token,
+    use_profile,
 )
 from ..output import print_json, print_success
 
@@ -22,7 +25,7 @@ def _mask_token(token: str | None) -> str | None:
 
 @click.group()
 def config():
-    """Manage local CLI configuration."""
+    """Manage local CLI configuration (supports multiple profiles)."""
     pass
 
 
@@ -33,39 +36,86 @@ def show_config(show_token):
     token = get_token()
     data = {
         "configFile": str(CONFIG_FILE),
+        "currentProfile": get_current_profile(),
         "baseUrl": get_base_url(),
         "hasToken": bool(token),
     }
     if token:
         data["token"] = token if show_token else _mask_token(token)
+    profiles = {}
+    for name, prof in list_profiles().items():
+        profiles[name] = {
+            "baseUrl": prof.get("base_url"),
+            "token": (prof.get("token") if show_token else _mask_token(prof.get("token"))),
+        }
+    if profiles:
+        data["profiles"] = profiles
     print_json(data)
+
+
+@config.command("list")
+def list_config():
+    """List all configured profiles."""
+    current = get_current_profile()
+    rows = {}
+    for name, prof in list_profiles().items():
+        rows[name] = {
+            "current": name == current,
+            "baseUrl": prof.get("base_url"),
+            "hasToken": bool(prof.get("token")),
+        }
+    print_json({"currentProfile": current, "profiles": rows})
+
+
+@config.command("use")
+@click.argument("name")
+@click.option("--base-url", "base_url", default=None, help="Set/override this profile's base URL")
+def use_config(name, base_url):
+    """Switch the active profile (creating it if needed).
+
+    Known names 'local' and 'prod' get their default URL automatically.
+    """
+    use_profile(name, base_url=base_url)
+    print_success("Active profile set", {"profile": name, "baseUrl": get_base_url(name)})
 
 
 @config.command("set-base-url")
 @click.argument("url")
-def set_base_url_command(url):
-    """Save a default API base URL."""
-    set_base_url(url)
-    print_success("Base URL saved", {"baseUrl": url})
+@click.option("--profile", "profile", default=None, help="Target profile (default: current)")
+def set_base_url_command(url, profile):
+    """Save a default API base URL (for the current or given profile)."""
+    if profile:
+        set_base_url(url, profile=profile)
+    else:
+        set_base_url(url)
+    print_success("Base URL saved", {"baseUrl": url, "profile": profile or get_current_profile()})
 
 
 @config.command("set-token")
 @click.argument("token")
-def set_token_command(token):
-    """Save a default auth token."""
-    set_token(token)
-    print_success("Token saved", {"token": _mask_token(token)})
+@click.option("--profile", "profile", default=None, help="Target profile (default: current)")
+def set_token_command(token, profile):
+    """Save a default auth token (for the current or given profile)."""
+    if profile:
+        set_token(token, profile=profile)
+    else:
+        set_token(token)
+    print_success("Token saved", {"token": _mask_token(token), "profile": profile or get_current_profile()})
 
 
 @config.command("clear-token")
-def clear_token_command():
-    """Remove only the saved auth token."""
-    clear_token()
+@click.option("--profile", "profile", default=None, help="Target profile (default: current)")
+def clear_token_command(profile):
+    """Remove only the saved auth token (for the current or given profile)."""
+    if profile:
+        clear_token(profile=profile)
+    else:
+        clear_token()
     print_success("Token cleared")
 
 
 @config.command("clear")
 def clear_all_config():
-    """Remove the local CLI config file."""
+    """Remove the local CLI config file (all profiles)."""
     clear_config()
     print_success("Config cleared")

--- a/cli/video_cli/commands/video.py
+++ b/cli/video_cli/commands/video.py
@@ -138,6 +138,121 @@ def create(ctx, filename, video_type):
         print_error(e.message, e.code)
 
 
+@video.command()
+@click.option("--file", "filepath", required=True, help="Path to the local video file to upload")
+@click.option("--title", default=None, help="Title (defaults to filename)")
+@click.option("--description", default=None, help="Description")
+@click.option(
+    "--visibility",
+    default=None,
+    type=click.Choice(["PUBLIC", "UNLISTED", "PRIVATE"]),
+    help="Visibility (defaults to server default)",
+)
+@click.option(
+    "--type",
+    "video_type",
+    default="USER_UPLOAD",
+    show_default=True,
+    type=click.Choice(["USER_UPLOAD", "UPLOAD", "YOUTUBE"], case_sensitive=False),
+    help="Video type",
+)
+@click.pass_context
+def upload(ctx, filepath, title, description, visibility, video_type):
+    """Upload a local video file end-to-end.
+
+    Runs the full flow: create -> getUploadCredentials -> OSS multipart
+    upload -> uploadFinish -> rawFileUploadFinish, then optionally sets
+    title/description/visibility.
+    """
+    base_url = ctx.obj.get("base_url")
+    token = ctx.obj.get("token")
+
+    if not os.path.isfile(filepath):
+        print_error(f"File not found: {filepath}")
+        return
+    try:
+        import oss2
+    except ImportError:
+        print_error("oss2 is required for upload. Install with: pip install oss2")
+        return
+
+    filename = os.path.basename(filepath)
+    size = os.path.getsize(filepath)
+    normalized_video_type = video_type.upper()
+    if normalized_video_type == "UPLOAD":
+        normalized_video_type = "USER_UPLOAD"
+
+    try:
+        # 1. Pre-create video to obtain fileId / videoId
+        created = post(
+            "/video/create",
+            {
+                "videoType": normalized_video_type,
+                "rawFilename": filename,
+                "size": size,
+                "ttl": "PERMANENT",
+            },
+            base_url=base_url,
+            token=token,
+        )
+        file_id = created.get("fileId")
+        video_id = created.get("videoId")
+
+        # 2. Fetch scoped STS credentials + target OSS key
+        creds = get("/file/getUploadCredentials", {"fileId": file_id}, base_url=base_url, token=token)
+        endpoint = creds["endpoint"]
+        if not endpoint.startswith("http"):
+            endpoint = "https://" + endpoint
+
+        # 3. Multipart upload to OSS (resumable, with progress)
+        auth = oss2.StsAuth(creds["accessKeyId"], creds["secretKey"], creds["sessionToken"])
+        bucket = oss2.Bucket(auth, endpoint, creds["bucket"])
+
+        last = {"pct": -1}
+
+        def _progress(consumed, total):
+            if total:
+                pct = int(consumed * 100 / total)
+                if pct != last["pct"]:
+                    last["pct"] = pct
+                    click.echo(f"\rUploading... {pct}%", nl=False, err=True)
+
+        oss2.resumable_upload(
+            bucket,
+            creds["key"],
+            filepath,
+            multipart_threshold=5 * 1024 * 1024,
+            part_size=1024 * 1024,
+            num_threads=3,
+            progress_callback=_progress,
+        )
+        click.echo("", err=True)
+
+        # 4. Mark raw file upload finished
+        get("/file/uploadFinish", {"fileId": file_id}, base_url=base_url, token=token)
+
+        # 5. Set metadata BEFORE triggering transcoding: the async transcode
+        #    thread re-saves the Video document, so a later updateInfo would
+        #    race with it and lose the title/visibility.
+        if title or description or visibility:
+            data = {"id": video_id}
+            data["title"] = title if title else os.path.splitext(filename)[0]
+            if description:
+                data["description"] = description
+            if visibility:
+                data["visibility"] = visibility
+            post("/video/updateInfo", data, base_url=base_url, token=token)
+
+        # 6. Trigger server-side processing / transcoding
+        get("/video/rawFileUploadFinish", {"videoId": video_id}, base_url=base_url, token=token)
+
+        print_success("Video uploaded", created)
+    except APIError as e:
+        print_error(e.message, e.code)
+    except Exception as e:  # noqa: BLE001 - surface OSS/network errors to the user
+        print_error(str(e))
+
+
 @video.command("download-url")
 @click.option("--id", "video_id", required=True, help="Video ID")
 @click.pass_context

--- a/cli/video_cli/config.py
+++ b/cli/video_cli/config.py
@@ -1,4 +1,19 @@
-"""Configuration management for video-cli."""
+"""Configuration management for video-cli.
+
+Supports multiple named profiles (e.g. local + prod) in a single config file,
+so different environments keep their own base_url and token side by side::
+
+    {
+      "current_profile": "prod",
+      "profiles": {
+        "local": {"base_url": "http://localhost:5022", "token": "..."},
+        "prod":  {"base_url": "https://oneclick.video", "token": "..."}
+      }
+    }
+
+Legacy flat configs ({"base_url": ..., "token": ...}) are still read and
+written in place for backward compatibility.
+"""
 import json
 from pathlib import Path
 
@@ -6,6 +21,13 @@ CONFIG_DIR = Path.home() / ".video-cli"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 
 DEFAULT_BASE_URL = "http://localhost:5022"
+DEFAULT_PROFILE = "default"
+
+# Convenience defaults so `config use <name>` knows well-known environments.
+KNOWN_PROFILE_URLS = {
+    "local": "http://localhost:5022",
+    "prod": "https://oneclick.video",
+}
 
 
 def _ensure_config_dir():
@@ -25,33 +47,112 @@ def save_config(config: dict):
         json.dump(config, f, indent=2, ensure_ascii=False)
 
 
-def get_token() -> str | None:
-    return load_config().get("token")
+def _is_profile_format(config: dict) -> bool:
+    return isinstance(config.get("profiles"), dict)
 
 
-def set_token(token: str):
+def _resolve_profile_name(config: dict, profile: str | None) -> str:
+    return profile or config.get("current_profile") or DEFAULT_PROFILE
+
+
+def _to_profile_format(config: dict) -> dict:
+    """Migrate a legacy flat config (or empty) into profile format in place."""
+    if _is_profile_format(config):
+        return config
+    legacy = {}
+    if config.get("base_url"):
+        legacy["base_url"] = config["base_url"]
+    if config.get("token"):
+        legacy["token"] = config["token"]
+    name = config.get("current_profile") or DEFAULT_PROFILE
+    profiles = {name: legacy} if legacy else {}
+    return {"current_profile": name, "profiles": profiles}
+
+
+# ---- profile management --------------------------------------------------
+
+def get_current_profile() -> str:
     config = load_config()
-    config["token"] = token
+    if _is_profile_format(config):
+        return config.get("current_profile") or DEFAULT_PROFILE
+    return DEFAULT_PROFILE
+
+
+def list_profiles() -> dict:
+    """Return {name: {base_url, token}} for all known profiles."""
+    config = load_config()
+    if _is_profile_format(config):
+        return config.get("profiles", {})
+    flat = {}
+    if config.get("base_url"):
+        flat["base_url"] = config["base_url"]
+    if config.get("token"):
+        flat["token"] = config["token"]
+    return {DEFAULT_PROFILE: flat} if flat else {}
+
+
+def use_profile(name: str, base_url: str | None = None):
+    """Switch the active profile, creating it if necessary."""
+    config = _to_profile_format(load_config())
+    profiles = config.setdefault("profiles", {})
+    prof = profiles.setdefault(name, {})
+    if base_url:
+        prof["base_url"] = base_url
+    elif "base_url" not in prof and name in KNOWN_PROFILE_URLS:
+        prof["base_url"] = KNOWN_PROFILE_URLS[name]
+    config["current_profile"] = name
     save_config(config)
 
 
-def clear_token():
+# ---- token / base_url accessors (profile-aware) --------------------------
+
+def get_token(profile: str | None = None) -> str | None:
     config = load_config()
-    if "token" in config:
-        del config["token"]
+    if _is_profile_format(config):
+        name = _resolve_profile_name(config, profile)
+        return config.get("profiles", {}).get(name, {}).get("token")
+    return config.get("token")
+
+
+def set_token(token: str, profile: str | None = None):
+    config = _to_profile_format(load_config())
+    name = _resolve_profile_name(config, profile)
+    config.setdefault("profiles", {}).setdefault(name, {})["token"] = token
+    config.setdefault("current_profile", name)
+    save_config(config)
+
+
+def clear_token(profile: str | None = None):
+    config = load_config()
+    if not config:
+        return
+    if _is_profile_format(config):
+        name = _resolve_profile_name(config, profile)
+        if name in config.get("profiles", {}):
+            config["profiles"][name].pop("token", None)
+        save_config(config)
+        return
+    # legacy flat: drop token in place, preserving the rest
+    config.pop("token", None)
     if config:
         save_config(config)
     else:
         clear_config()
 
 
-def get_base_url() -> str:
-    return load_config().get("base_url", DEFAULT_BASE_URL)
-
-
-def set_base_url(url: str):
+def get_base_url(profile: str | None = None) -> str:
     config = load_config()
-    config["base_url"] = url
+    if _is_profile_format(config):
+        name = _resolve_profile_name(config, profile)
+        return config.get("profiles", {}).get(name, {}).get("base_url") or DEFAULT_BASE_URL
+    return config.get("base_url", DEFAULT_BASE_URL)
+
+
+def set_base_url(url: str, profile: str | None = None):
+    config = _to_profile_format(load_config())
+    name = _resolve_profile_name(config, profile)
+    config.setdefault("profiles", {}).setdefault(name, {})["base_url"] = url
+    config.setdefault("current_profile", name)
     save_config(config)
 
 

--- a/cli/video_cli/main.py
+++ b/cli/video_cli/main.py
@@ -1,24 +1,34 @@
 """video-cli: CLI tool for video-2022 platform."""
 import click
 from . import __version__
+from .config import get_base_url, get_token
 from .commands import auth, video, comment, like, playlist, youtube, stats, watch, search, api, developer, notification, share, config as config_commands
 
 
 @click.group()
 @click.option("--base-url", envvar="VIDEO_CLI_BASE_URL", help="API base URL (default: http://localhost:5022)")
 @click.option("--token", envvar="VIDEO_CLI_TOKEN", help="Auth token (overrides saved token)")
+@click.option("--profile", "-p", envvar="VIDEO_CLI_PROFILE", help="Config profile to use (e.g. local, prod)")
 @click.option("--output", "output_format", type=click.Choice(["json", "table"]), default="json", help="Output format")
 @click.version_option(__version__, prog_name="video-cli")
 @click.pass_context
-def cli(ctx, base_url, token, output_format):
+def cli(ctx, base_url, token, profile, output_format):
     """video-cli — Agent-friendly CLI for video-2022 platform.
 
     Manage videos, users, comments, playlists, and more from the command line.
     All commands output JSON by default for easy integration with AI agents and scripts.
     """
     ctx.ensure_object(dict)
-    ctx.obj["base_url"] = base_url
-    ctx.obj["token"] = token
+    ctx.obj["profile"] = profile
+    # When a profile is explicitly selected, resolve its base_url/token now so
+    # this invocation targets that environment. Without --profile we leave them
+    # unset and let the client lazily fall back to the saved current profile.
+    if profile:
+        ctx.obj["base_url"] = base_url or get_base_url(profile)
+        ctx.obj["token"] = token or get_token(profile)
+    else:
+        ctx.obj["base_url"] = base_url
+        ctx.obj["token"] = token
     ctx.obj["output_format"] = output_format
 
 


### PR DESCRIPTION
## 背景
要把本地视频上传到生产（oneclick.video），发现 CLI 只有 `video create`（仅预创建元数据、不上传字节），缺真正的端到端上传；且 config 只能存一套 base_url+token，本地和生产互相覆盖。

## 改动
- **`video upload`**：一条命令完成完整流程 —— create → `/file/getUploadCredentials` 取 OSS STS 凭证 → oss2 multipart 直传 → `/file/uploadFinish` → `/video/rawFileUploadFinish` 触发转码，带进度条。
- **顺序修正**：metadata（title/visibility）在触发转码**之前**写入。否则异步转码线程回写 Video 文档会覆盖掉 title（实测复现）。
- **多环境 profile**：`~/.video-cli/config.json` 改为多 profile 结构，`local` / `prod` 各存各的 base_url 与 token；新增 `config use` / `config list`、全局 `--profile/-p`、`VIDEO_CLI_PROFILE` 环境变量；旧扁平配置自动兼容迁移。
- 依赖新增 `oss2`；README 补充上传与多环境 profile 用法。

## 测试
- `pytest` 全套 118 passed。
- 已用该命令成功上传一个 PUBLIC 视频到生产并转码完成（READY）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)