### PR TITLE
ci: 升级 deploy/release 残留的 Node20 action 到 v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
@@ -104,7 +104,7 @@ jobs:
           npm run build
 
       - name: 上传构建产物
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: console-dist
           path: console/dist/
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: 下载控制台产物
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: console-dist
           path: console-dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
     if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'both' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -101,7 +101,7 @@ jobs:
             }'
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: android-apk-v${{ github.event.inputs.version_name }}
           path: android/app/build/outputs/apk/debug/*.apk
@@ -111,7 +111,7 @@ jobs:
     if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'both' }}
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install xcodegen
         run: brew install xcodegen


### PR DESCRIPTION
## 背景
GitHub Actions 提示 `actions/setup-node@v4`、`actions/upload-artifact@v4` 等仍运行在 Node.js 20，2026-06-16 起强制 Node 24、09-16 从 runner 移除。

`ci.yml` 早已全部升到 v5/v6，只有 `deploy.yml` 和 `release.yml` 残留 v4。

## 改动
- `deploy.yml`：`setup-node` `upload-artifact` `download-artifact` v4 → v5
- `release.yml`：`checkout` `setup-java` `upload-artifact` v4 → v5
- `actions/cache` 暂无 v5 大版本、未在弃用警告中，保持 `@v4`

均与 `ci.yml` 已验证使用的版本一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)