### PR TITLE
fix: @Indexed 用 expireAfter 替换已废弃的 expireAfterSeconds

### DIFF
--- a/server/video/src/main/java/com/github/makewheels/video2022/user/bean/VerificationCode.java
+++ b/server/video/src/main/java/com/github/makewheels/video2022/user/bean/VerificationCode.java
@@ -14,6 +14,6 @@ public class VerificationCode {
     @Indexed(unique = true)
     private String phone;
     private String code;
-    @Indexed(expireAfterSeconds = 600)
+    @Indexed(expireAfter = "600s")
     private Date createdAt;
 }

--- a/server/video/src/main/java/com/github/makewheels/video2022/utils/IpCache.java
+++ b/server/video/src/main/java/com/github/makewheels/video2022/utils/IpCache.java
@@ -14,6 +14,6 @@ public class IpCache {
     @Indexed(unique = true)
     private String ip;
     private String locationJson;
-    @Indexed(expireAfterSeconds = 21600)
+    @Indexed(expireAfter = "21600s")
     private Date createdAt;
 }


### PR DESCRIPTION
## 背景
后端编译警告：`@Indexed(expireAfterSeconds=...)` 在 Spring Data MongoDB 中已废弃并标记移除（`[removal]`）。

## 改动
改用等价的 `expireAfter` 字符串形式：
- `IpCache.createdAt`：`21600s`（6 小时 TTL）
- `VerificationCode.createdAt`：`600s`（10 分钟 TTL）

值与原来完全等价，仅消除弃用警告。运行时 TTL 索引创建由 CI 的 `后端测试`（连 mongo:7 service）验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)