### PR TITLE
fix: 转码线程异常不再未捕获崩溃，MPS 空响应明确报错

### DIFF
--- a/server/video/src/main/java/com/github/makewheels/video2022/transcode/TranscodeLauncher.java
+++ b/server/video/src/main/java/com/github/makewheels/video2022/transcode/TranscodeLauncher.java
@@ -158,7 +158,12 @@ public class TranscodeLauncher {
 
         log.info("通过阿里云MPS获取视频信息，videoId = {}, title = {}", videoId, video.getTitle());
         //获取视频媒体信息，确定只用阿里云mps，不用其它供应商
-        SubmitMediaInfoJobResponseBody body = aliyunMpsService.getMediaInfo(sourceKey).getBody();
+        var mediaInfoResponse = aliyunMpsService.getMediaInfo(sourceKey);
+        if (mediaInfoResponse == null || mediaInfoResponse.getBody() == null) {
+            throw new IllegalStateException(
+                    "阿里云MPS获取媒体信息失败（返回为空），videoId = " + videoId + ", sourceKey = " + sourceKey);
+        }
+        SubmitMediaInfoJobResponseBody body = mediaInfoResponse.getBody();
         SubmitMediaInfoJobResponseBody.SubmitMediaInfoJobResponseBodyMediaInfoJob job
                 = body.getMediaInfoJob();
         log.info("阿里云MPS获取视频媒体信息，jobId ={}，接口返回：{}", job.getJobId(), JSON.toJSONString(job));

--- a/server/video/src/main/java/com/github/makewheels/video2022/video/service/VideoService.java
+++ b/server/video/src/main/java/com/github/makewheels/video2022/video/service/VideoService.java
@@ -88,7 +88,13 @@ public class VideoService {
         checkService.checkFileIsReady(file);
 
         //创建子线程发起转码，先给前端返回结果
-        new Thread(() -> rawFileService.onRawFileUploadFinish(videoId)).start();
+        new Thread(() -> {
+            try {
+                rawFileService.onRawFileUploadFinish(videoId);
+            } catch (Exception e) {
+                log.error("转码处理线程异常，videoId = {}", videoId, e);
+            }
+        }).start();
     }
 
     /**


### PR DESCRIPTION
## 背景
CI 后端测试日志里出现一大段红色堆栈：
```
Exception in thread "Thread-4" java.lang.NullPointerException:
  Cannot invoke "...SubmitMediaInfoJobResponse.getBody()" because the return value of
  "AliyunMpsService.getMediaInfo(String)" is null
    at TranscodeLauncher.loadMediaInfoIntoVideo(TranscodeLauncher.java:161)
```
**测试本身是通过的**（`Tests run: 1, Failures: 0, Errors: 0`）——这是 `rawFileUploadFinish` 派生的**异步转码线程**里抛的未捕获异常：测试环境用 mock 的 `AliyunMpsService`，`getMediaInfo` 未打桩默认返回 `null`，调用方直接 `.getBody()` → NPE。GitHub Actions 把未捕获线程异常标成 `Error:`，看着像挂了。

## 改动（保守，不改正常流程）
- `TranscodeLauncher.loadMediaInfoIntoVideo`：`getMediaInfo` 返回 `null` 或 body 为空时显式判空，抛出带 `videoId`/`sourceKey` 的 `IllegalStateException`，取代隐晦的 NPE。这也是生产健壮性改进——MPS 调用失败（`AliyunMpsService` 内部已 catch 并返回 null）时不再 NPE。
- `VideoService.rawFileUploadFinish`：转码子线程包 `try/catch`，异常走 `log.error` 受控记录，而非未捕获崩溃线程（消除 "Exception in thread Thread-4" 整段堆栈）。

不引入失败状态枚举（现无 FAILED 态），不改视频状态语义。

## 测试
- 本地 `mvn -pl video -Pspringboot compile` 通过。
- 集成测试由 CI 的 `后端测试`（连 mongo:7）验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)